### PR TITLE
Add function to validate cronjob schedule on frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "ui",
       "version": "0.1.0",
       "dependencies": {
-        "@datasert/cronjs-parser": "^1.2.0",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@fontsource/roboto": "^5.0.8",
@@ -18,6 +17,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.5.1",
+        "cron-parser": "^4.9.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -2276,11 +2276,6 @@
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.10"
       }
-    },
-    "node_modules/@datasert/cronjs-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@datasert/cronjs-parser/-/cronjs-parser-1.2.0.tgz",
-      "integrity": "sha512-7kzYh7F5V3ElX+k3W9w6SKS6WdjqJQ2gIY1y0evldnjAwZxnFzR/Yu9Mv9OeDaCQX+mGAq2MvEnJbwu9oj3CXQ=="
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.11.0",
@@ -6740,6 +6735,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -12691,6 +12697,14 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.3.tgz",
+      "integrity": "sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lz-string": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ui",
       "version": "0.1.0",
       "dependencies": {
+        "@datasert/cronjs-parser": "^1.2.0",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
         "@fontsource/roboto": "^5.0.8",
@@ -2275,6 +2276,11 @@
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.10"
       }
+    },
+    "node_modules/@datasert/cronjs-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@datasert/cronjs-parser/-/cronjs-parser-1.2.0.tgz",
+      "integrity": "sha512-7kzYh7F5V3ElX+k3W9w6SKS6WdjqJQ2gIY1y0evldnjAwZxnFzR/Yu9Mv9OeDaCQX+mGAq2MvEnJbwu9oj3CXQ=="
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.11.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@datasert/cronjs-parser": "^1.2.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@fontsource/roboto": "^5.0.8",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@datasert/cronjs-parser": "^1.2.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@fontsource/roboto": "^5.0.8",
@@ -13,6 +12,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.5.1",
+    "cron-parser": "^4.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/src/components/AddMonitorForm.jsx
+++ b/src/components/AddMonitorForm.jsx
@@ -1,5 +1,6 @@
 import { Box, FormControl, FormLabel, TextField, Button } from '@mui/material';
 import { useState } from 'react';
+import {scheduleParser} from '../utils/validateSchedule';
 
 const AddMonitorForm = ({ handleSubmitForm, handleBack }) => {
   const [schedule, setSchedule] = useState('');
@@ -11,6 +12,12 @@ const AddMonitorForm = ({ handleSubmitForm, handleBack }) => {
     e.preventDefault();
     if (!schedule) {
       alert("Must have a schedule.");
+      return;
+    }
+    const parsedSchedule = scheduleParser(schedule);
+
+    if (!parsedSchedule.valid) {
+      alert(parsedSchedule.error);
       return;
     }
 

--- a/src/utils/validateSchedule.js
+++ b/src/utils/validateSchedule.js
@@ -1,0 +1,17 @@
+const {parse} = require('@datasert/cronjs-parser') ;
+
+const scheduleParser = (scheduleStr) => {
+  let returnObj = {valid: null, error:null};
+  try {
+    parse(scheduleStr);
+    returnObj.valid = true;
+    return returnObj;
+  } catch (err) {
+    returnObj.valid = false;
+    returnObj.error = err.message;
+    return returnObj;
+  }
+}
+
+
+module.exports ={scheduleParser};

--- a/src/utils/validateSchedule.js
+++ b/src/utils/validateSchedule.js
@@ -1,9 +1,9 @@
-const {parse} = require('@datasert/cronjs-parser') ;
+const parser = require('cron-parser') ;
 
 const scheduleParser = (scheduleStr) => {
   let returnObj = {valid: null, error:null};
   try {
-    parse(scheduleStr);
+    parser.parseExpression(scheduleStr);
     returnObj.valid = true;
     return returnObj;
   } catch (err) {


### PR DESCRIPTION
Added the `validateSchedule.js` file in the `utils` folder, which contains a function to validate the user-entered schedule. It uses the npm package `cronjs-parser`. The function returns an object with a valid attribute (boolean) and an error attribute (error message, otherwise null).

In the case of an invalid schedule, the user is presented an alert with the first issue encountered, starting in the minutes entry and going rightwards. If the schedule has errors in more than one of the entries, they will continue to get single alerts upon submit until the schedule is valid.

Issue with minutes entry
![Screen Shot 2023-10-18 at 1 00 03 PM](https://github.com/Sundial-Inc/ui/assets/10123446/627f9fce-98c2-44e7-acbf-81a51e73af63)

Issue with hours entry
![Screen Shot 2023-10-18 at 1 00 55 PM](https://github.com/Sundial-Inc/ui/assets/10123446/da92e0b3-4d35-460c-9e33-e21790d86987)
