### PR TITLE
Display next runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.5.1",
+        "cron-parser": "^4.9.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -6736,6 +6737,17 @@
         "node": ">=10"
       }
     },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -12685,6 +12697,14 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.3.tgz",
+      "integrity": "sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.5.1",
+    "cron-parser": "^4.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/src/components/Monitor.jsx
+++ b/src/components/Monitor.jsx
@@ -1,5 +1,6 @@
 import { ListItem, ListItemButton, ListItemText, Typography } from '@mui/material';
 import generateCurl from '../utils/generateCurl';
+import nextRun from '../utils/nextRun';
 
 export const Monitor = ({ monitor, count }) => {
   const sx = monitor.failing ?
@@ -17,8 +18,8 @@ export const Monitor = ({ monitor, count }) => {
                 <Typography variant="subtitle1">Name: {monitor.name}</Typography>
                 <Typography variant="subtitle1">Wrapper: {generateCurl(monitor)}</Typography>
                 <Typography variant="subtitle1">Schedule: {monitor.schedule}</Typography>
-                <Typography variant="subtitle1">Next Expected At: {monitor.next_expected_at}</Typography>
-                <Typography variant="subtitle1">Failed: {monitor.failed}</Typography>
+                <Typography variant="subtitle1">Next Expected At: {nextRun(monitor.schedule)}</Typography>
+                <Typography variant="subtitle1">Status: {monitor.failing ? 'Failed' : 'Running'}</Typography>
               </div>
             }
             primary={`Monitor #${count}`}

--- a/src/utils/nextRun.js
+++ b/src/utils/nextRun.js
@@ -1,0 +1,10 @@
+import parser from 'cron-parser';
+
+const nextRun = (schedule) => {
+  return parser.parseExpression(
+    schedule,
+    { currentDate: new Date() }
+  ).next().toString();
+};
+
+export default nextRun;


### PR DESCRIPTION
- added a util method that generates the next expected runtime of a given schedule
- "next expected at: " column on ui now displays this value
- changed the "Failed: " column to "Status: " on the display - has value either "running" or "failed". Definitely something that should be adjusted later - perhaps "running" for if a job has sent a start ping - or just removed. Nice to have for now.