### PR TITLE
Delete button

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import useTemporaryMessages from './hooks/useTemporaryMessages';
 import { Button, Box } from '@mui/material';
-import { createMonitor, getMonitors } from './services/monitors';
+import { createMonitor, getMonitors, deleteMonitor } from './services/monitors';
 import MonitorsList from './components/MonitorsList';
 import Header from './components/Header';
 import AddMonitorForm from './components/AddMonitorForm';
@@ -28,7 +28,7 @@ const App = () => {
     }
 
     addErrorMessage(message);
-  }
+  };
 
   useEffect(() => {
     const fetchMonitors = async () => {
@@ -43,11 +43,11 @@ const App = () => {
     fetchMonitors();
   }, []);
 
-  const onClickNewMonitorButton = (e) => {
+  const handleClickNewMonitorButton = (e) => {
     setDisplayAddForm(true);
-  }
+  };
 
-  const onClickSubmitNewMonitor = async (monitorData) => {
+  const handleClickSubmitNewMonitor = async (monitorData) => {
     try { 
       const newMonitor = await createMonitor(monitorData);
       const wrapper = generateCurl(newMonitor);
@@ -58,17 +58,27 @@ const App = () => {
     } catch (error) {
       handleAxiosError(error);
     }
-  }
+  };
 
-  const onClosePopover = () => {
+  const handleClosePopover = () => {
     setDisplayString(false);
     setWrapper('');
     setDisplayAddForm(false);
-  }
+  };
 
-  const onClickBackButton = () => {
+  const handleClickBackButton = () => {
     setDisplayAddForm(false);
-  }
+  };
+
+  const handleClickDeleteButton = async (monitorId) => {
+    try {
+      await deleteMonitor(monitorId);
+      setMonitors(monitors.filter(({ id }) => id !== monitorId));
+      addSuccessMessage('Monitor deleted successfully')
+    } catch (error) {
+      handleAxiosError(error);
+    }
+  };
 
   return (
     <div>
@@ -85,19 +95,19 @@ const App = () => {
           <Button 
             open={displayAddForm} 
             variant="contained" 
-            onClick={onClickNewMonitorButton}>Add Monitor
+            onClick={handleClickNewMonitorButton}>Add Monitor
           </Button> 
         </Box>}
       {displayAddForm ? 
         <AddMonitorForm 
-          handleSubmitForm={onClickSubmitNewMonitor}
-          handleBack={onClickBackButton}
+          onSubmitForm={handleClickSubmitNewMonitor}
+          onBack={handleClickBackButton}
           addErrorMessage={addErrorMessage}/> : 
-        <MonitorsList monitors={monitors}/> }
+        <MonitorsList monitors={monitors} onDelete={handleClickDeleteButton} /> }
       <WrapperPopover 
         wrapper={wrapper} 
         open={displayString} 
-        handleClose={onClosePopover}
+        onClose={handleClosePopover}
       />
     </div>
   );

--- a/src/components/AddMonitorForm.jsx
+++ b/src/components/AddMonitorForm.jsx
@@ -2,13 +2,13 @@ import { Box, FormControl, FormLabel, TextField, Button } from '@mui/material';
 import { useState } from 'react';
 import {scheduleParser} from '../utils/validateSchedule';
 
-const AddMonitorForm = ({ handleSubmitForm, handleBack, addErrorMessage }) => {
+const AddMonitorForm = ({ onSubmitForm, onBack, addErrorMessage }) => {
   const [schedule, setSchedule] = useState('');
   const [name, setMonitorName] = useState('');
   const [command, setCommand] = useState('');
   const [notifyTime, setNotifyTime] = useState('');
 
-  const onClickSubmitForm = (e) => {
+  const handleSubmitForm = (e) => {
     e.preventDefault();
     if (!schedule) {
       addErrorMessage("Must have a schedule.");
@@ -28,13 +28,13 @@ const AddMonitorForm = ({ handleSubmitForm, handleBack, addErrorMessage }) => {
       grace_period: notifyTime || undefined,
     };
 
-    return handleSubmitForm(monitorData);
+    return onSubmitForm(monitorData);
   }
 
   return (
     <>
       <div>
-        <Button sx={{ width: '120px', margin: '10px' }} onClick={handleBack}>Back</Button>
+        <Button sx={{ width: '120px', margin: '10px' }} onClick={onBack}>Back</Button>
       </div>
       <FormControl margin="normal" variant="outlined" sx={{margin: '30px' }} >
         <FormLabel>New Monitor</FormLabel>
@@ -79,7 +79,7 @@ const AddMonitorForm = ({ handleSubmitForm, handleBack, addErrorMessage }) => {
               justifyContent: 'center',
             }}
             >
-            <Button sx={{ width: '100%' }} onClick={onClickSubmitForm}>Submit</Button>
+            <Button sx={{ width: '100%' }} onClick={handleSubmitForm}>Submit</Button>
           </Box>
         </Box>
       </FormControl>

--- a/src/components/CopyToClipboardButton.jsx
+++ b/src/components/CopyToClipboardButton.jsx
@@ -1,22 +1,22 @@
 import { Button, Snackbar } from '@mui/material'
 import { useState } from 'react'
 
-const CopyToClipboardButton = ({ wrapper, handleClose }) => {
+const CopyToClipboardButton = ({ wrapper, onClose }) => {
   const [open, setOpen] = useState(false);
 
-  const onClick = () => {
+  const handleClick = () => {
     setOpen(true);
     navigator.clipboard.writeText(wrapper);
   }
   
   return (
     <>
-      <Button onClick={onClick}>Copy</Button>
+      <Button onClick={handleClick}>Copy</Button>
       <Snackbar
         open={open}
         onClose={() => {
           setOpen(false);
-          handleClose();
+          onClose();
         }}
         autoHideDuration={500}
         message="Copied to clipboard"

--- a/src/components/DeleteButton.jsx
+++ b/src/components/DeleteButton.jsx
@@ -1,0 +1,12 @@
+import { Button } from '@mui/material';
+import { Delete } from '@mui/icons-material';
+
+const DeleteButton = ({ onDelete }) => {
+  return (
+    <Button onClick={onDelete} variant="outlined" startIcon={<Delete />}>
+      Delete
+    </Button>
+  )
+};
+
+export default DeleteButton;

--- a/src/components/Monitor.jsx
+++ b/src/components/Monitor.jsx
@@ -1,8 +1,9 @@
 import { ListItem, ListItemButton, ListItemText, Typography } from '@mui/material';
+import DeleteButton from './DeleteButton';
 import generateCurl from '../utils/generateCurl';
 import nextRun from '../utils/nextRun';
 
-export const Monitor = ({ monitor, count }) => {
+export const Monitor = ({ monitor, count, onDelete }) => {
   const sx = monitor.failing ?
     { bgcolor: "red" } :
     null;
@@ -20,6 +21,7 @@ export const Monitor = ({ monitor, count }) => {
                 <Typography variant="subtitle1">Schedule: {monitor.schedule}</Typography>
                 <Typography variant="subtitle1">Next Expected At: {nextRun(monitor.schedule)}</Typography>
                 <Typography variant="subtitle1">Status: {monitor.failing ? 'Failed' : 'Running'}</Typography>
+                <DeleteButton onDelete={() => onDelete(monitor.id)} />
               </div>
             }
             primary={`Monitor #${count}`}

--- a/src/components/MonitorsList.jsx
+++ b/src/components/MonitorsList.jsx
@@ -1,14 +1,20 @@
 import {Box, List} from '@mui/material';
 import { Monitor } from './Monitor';
 
-const MonitorsList = ({ monitors }) => {
+const MonitorsList = ({ monitors, onDelete }) => {
   return (
     <div>
       <h1>Monitors</h1>
       <Box sx={{ width: '100%', maxWidth: 360, bgcolor: 'background.paper' }}>
         <nav aria-label="main mailbox folders">
           <List>
-              {monitors.map((monitor, ind) => <Monitor key={monitor.id} monitor={monitor} count={ind + 1}/>)}
+              {monitors.map((monitor, ind) => 
+                <Monitor 
+                  key={monitor.id} 
+                  monitor={monitor} 
+                  count={ind + 1}
+                  onDelete={onDelete} />
+              )}
           </List>
         </nav>
       </Box>

--- a/src/components/WrapperPopover.jsx
+++ b/src/components/WrapperPopover.jsx
@@ -1,12 +1,12 @@
 import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button } from '@mui/material'; 
 import CopyToClipboardButton from './CopyToClipboardButton.jsx';
 
-const WrapperPopover = ({ wrapper, open, handleClose }) => {
+const WrapperPopover = ({ wrapper, open, onClose }) => {
   return ( 
     <div>
       <Dialog
         open={open}
-        onClose={handleClose}
+        onClose={onClose}
         aria-labelledby="alert-dialog-title"
         aria-describedby="alert-dialog-description"
       >
@@ -19,12 +19,12 @@ const WrapperPopover = ({ wrapper, open, handleClose }) => {
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={handleClose}>Close</Button>
-          <CopyToClipboardButton wrapper={wrapper} handleClose={handleClose} autoFocus/>
+          <Button onClick={onClose}>Close</Button>
+          <CopyToClipboardButton wrapper={wrapper} onClose={onClose} autoFocus/>
         </DialogActions>
       </Dialog>
     </div>
   );
 }
- 
+
 export default WrapperPopover;

--- a/src/constants/routes.js
+++ b/src/constants/routes.js
@@ -1,4 +1,5 @@
 export const BASE_URL = process.env.REACT_APP_SERVER_URL;
 export const GET_MONITORS = '/api/monitors';
 export const CREATE_MONITOR = '/api/monitors';
+export const DELETE_MONITOR = '/api/monitors/';
 export const CREATE_PING = '/api/pings';

--- a/src/services/monitors.js
+++ b/src/services/monitors.js
@@ -2,7 +2,8 @@ import axios from "axios";
 import {
   BASE_URL,
   CREATE_MONITOR,
-  GET_MONITORS
+  GET_MONITORS,
+  DELETE_MONITOR
 } from "../constants/routes";
 
 export const getMonitors = async () => {
@@ -13,4 +14,8 @@ export const getMonitors = async () => {
 export const createMonitor = async (newMonitor) => {
   const { data } = await axios.post(BASE_URL + CREATE_MONITOR, newMonitor);
   return data;
+};
+
+export const deleteMonitor = async (id) => {
+  await axios.delete(BASE_URL + DELETE_MONITOR + String(id));
 };


### PR DESCRIPTION
## Changes
- added a delete button to the monitor list items
- created a `deleteMonitor` service method that makes a DELETE request to /api/monitors/:id
- on clicking the delete button the above method is called
- if successful, that monitor is removed from the `monitors` state
- a success notification is displayed
## Housekeeping
- changed the naming of most helper methods and component attributes. Methods: `onSomeAction` => `handleSomeAction`; Attributes: `handleSomeAction` => `onSomeAction`. I think we had these the wrong way round... could someone please confirm?
## Future Features
- the delete button should have a popup that confirms the user's action